### PR TITLE
Added trending as default results initially or in empty search

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ If you need access to the actual `div` that `Tenor` renders, you can pass any va
 
 If you want the search bar to start pre-populated with a specific value, you can pass an `initialSearch` prop.
 
+### `defaultResults`
+
+If you need to show trending results in an initial rendering without any initialSearch, you can pass `defaultResults` prop.
+
 ### `focus()`
 
 The `Tenor` component has a `focus()` member function that can be called to request focus be placed on the search input.

--- a/src/Client.js
+++ b/src/Client.js
@@ -8,6 +8,7 @@ class Client {
   constructor(options = {}) {
     this.base = options.base || "https://api.tenor.com/v1";
     this.token = options.token || "LIVDSRZULELA";
+    this.defaultResults = options.defaultResults || false;
   }
 
   autocomplete(search) {
@@ -16,7 +17,11 @@ class Client {
   }
 
   search(search, params = {}) {
-    return fetch(`${this.base}/search${this.searchQueryFor(search, params)}`)
+    let searchQuery = `${this.base}/search${this.searchQueryFor(search, params)}`;
+    if(this.defaultResults && !search) {
+      searchQuery = `${this.base}/trending${this.searchQueryFor(search, params)}`;
+    }
+    return fetch(searchQuery)
       .then(response => response.json());
   }
 

--- a/src/Tenor.js
+++ b/src/Tenor.js
@@ -24,8 +24,8 @@ class Tenor extends Component {
   constructor(props) {
     super(props);
 
-    const { base, token } = props;
-    this.client = new Client({ base, token });
+    const { base, token, defaultResults } = props;
+    this.client = new Client({ base, token, defaultResults });
 
     this.contentRef = React.createRef();
     this.inputRef = React.createRef();
@@ -38,13 +38,13 @@ class Tenor extends Component {
   }
 
   componentDidMount() {
-    const { initialSearch } = this.props;
+    const { initialSearch, defaultResults } = this.props;
 
     this.componentIsMounted = true;
     window.addEventListener("keydown", this.handleWindowKeyDown);
     window.addEventListener("click", this.handleWindowClick);
 
-    if (initialSearch) {
+    if (initialSearch || defaultResults) {
       this.fetchAutocomplete(initialSearch);
       this.fetchSuggestions(initialSearch);
       this.performSearch(initialSearch);
@@ -137,7 +137,7 @@ class Tenor extends Component {
       searching
     } = this.state;
 
-    if (!search || searching) {
+    if ((!this.props.defaultResults && !search) || searching) {
       return Promise.resolve();
     }
 
@@ -164,7 +164,7 @@ class Tenor extends Component {
       clearTimeout(this.timeout);
     }
 
-    if (!search.length) {
+    if (!this.props.defaultResults && !search.length) {
       this.setState(DEFAULT_STATE);
       return;
     }


### PR DESCRIPTION
Now you can use trending results initially as default using defaultResults prop:
```jsx
<Tenor defaultResults onSelect={result => console.log(result)} />
```

and also you can add both initialSearch and defaultResults props; it will show pre-populate search initially and when you empty the search, it will show trending results:
```jsx
<Tenor defaultResults initialSearch="some_search" onSelect={result => console.log(result)} />
```