### PR TITLE
safesearch should be contentFilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Below is a list of all of the props you can pass to the `Tenor` component.
 | `locale` | `string` | `"en_US"` | The locale that gets passed up to tenor. See the [tenor API docs](https://tenor.com/gifapi/documentation) for details. |
 | `mediaFilter` | `string` | `"minimal"`  | The media filter that gets passed up to tenor. See the [tenor API docs](https://tenor.com/gifapi/documentation) for details. |
 | `onSelect` | `Result => void` | | A callback for when the user selects a GIF. |
-| `safesearch` | `string` | `"mild"` | The safe search that gets passed up to tenor. See the [tenor API docs](https://tenor.com/gifapi/documentation) for details. |
+| `contentFilter` | `string` | `"mild"` | The content filter that gets passed up to tenor. See the [tenor API docs](https://tenor.com/gifapi/documentation) for details. Extra about [content filtering](https://tenor.com/gifapi/documentation#contentfilter) |
 | `token` | `string` | | The tenor API token. See the [tenor API docs](https://tenor.com/gifapi/documentation) for details. |
 
 ### Functions

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -41,7 +41,7 @@ type ClientOptions = {
   base?: string;
   token?: string;
   locale?: string;
-  safesearch?: string;
+  contentFilter?: string;
   mediaFilter?: string;
   defaultResults?: boolean;
 };
@@ -53,17 +53,17 @@ class Client { /* eslint-disable @typescript-eslint/camelcase */
 
   private locale: string;
 
-  private safesearch: string;
+  private contentFilter: string;
 
   private mediaFilter: string;
 
   private defaultResults: boolean;
 
-  constructor({ base, token, locale, mediaFilter, safesearch, defaultResults }: ClientOptions) {
+  constructor({ base, token, locale, mediaFilter, contentFilter, defaultResults }: ClientOptions) {
     this.base = base || "https://api.tenor.com/v1";
     this.token = token || "LIVDSRZULELA";
     this.locale = locale || "en_US";
-    this.safesearch = safesearch || "mild";
+    this.contentFilter = contentFilter || "mild";
     this.mediaFilter = mediaFilter || "minimal";
     this.defaultResults = defaultResults || false;
   }
@@ -85,7 +85,7 @@ class Client { /* eslint-disable @typescript-eslint/camelcase */
       q: search,
       limit: 12,
       locale: this.locale,
-      safesearch: this.safesearch,
+      contentfilter: this.contentFilter,
       media_filter: this.mediaFilter,
       ar_range: "all",
       pos

--- a/src/Tenor.tsx
+++ b/src/Tenor.tsx
@@ -32,7 +32,7 @@ type TenorProps = {
   token: string;
   locale?: string;
   mediaFilter?: string;
-  safesearch?: string;
+  contentFilter?: string;
 };
 
 type TenorState = {
@@ -62,8 +62,8 @@ class Tenor extends React.Component<TenorProps, TenorState> {
   constructor(props: TenorProps) {
     super(props);
 
-    const { base, token, locale, mediaFilter, safesearch, defaultResults } = props;
-    this.client = new Client({ base, token, locale, mediaFilter, safesearch, defaultResults });
+    const { base, token, locale, mediaFilter, contentFilter, defaultResults } = props;
+    this.client = new Client({ base, token, locale, mediaFilter, contentFilter, defaultResults });
 
     this.contentRef = React.createRef();
     this.inputRef = React.createRef();
@@ -100,17 +100,17 @@ class Tenor extends React.Component<TenorProps, TenorState> {
   }
 
   componentDidUpdate(prevProps: TenorProps) {
-    const { base, token, locale, mediaFilter, safesearch, defaultResults } = this.props;
+    const { base, token, locale, mediaFilter, contentFilter, defaultResults } = this.props;
 
     if (
       base !== prevProps.base
       || token !== prevProps.token
       || locale !== prevProps.locale
       || mediaFilter !== prevProps.mediaFilter
-      || safesearch !== prevProps.safesearch
+      || contentFilter !== prevProps.contentFilter
       || defaultResults !== prevProps.defaultResults
     ) {
-      this.client = new Client({ base, token, locale, mediaFilter, safesearch, defaultResults });
+      this.client = new Client({ base, token, locale, mediaFilter, contentFilter, defaultResults });
     }
   }
 


### PR DESCRIPTION
Be closer inspection of the API, it seems like "safesearch" is actually renamed to contentFilter. 

https://tenor.com/gifapi/documentation#endpoints-search
https://tenor.com/gifapi/documentation#contentfilter